### PR TITLE
Make github actions cache always available

### DIFF
--- a/.github/scripts/cache-update-report-generator.js
+++ b/.github/scripts/cache-update-report-generator.js
@@ -1,0 +1,38 @@
+module.exports = async () => {
+    try {
+      const cacheData = await getCacheData();
+      let report = `Found ${cacheData.total_count} caches for Jetflix. Here are the status of them:`;
+      const locale = 'tr-TR';
+      cacheData.actions_caches.forEach(cache => {
+        report += `\n\nBranch: ${cache.ref.split('/').pop()}\nName: ${cache.key}\n`;
+        const accessed = new Date(cache.last_accessed_at);
+        const created = new Date(cache.created_at);
+        report += `Created: ${created.toLocaleDateString(locale)} ${created.toLocaleTimeString(locale)}\n`;
+        report += `Last accessed: ${accessed.toLocaleDateString(locale)} ${accessed.toLocaleTimeString(locale)}\n`;
+        const sizeInGb = cache.size_in_bytes / 1024 / 1024 / 1024;
+        const sizeInMb = cache.size_in_bytes / 1024 / 1024;
+        let sizeString = '';
+        if (sizeInGb >= 1) {
+          sizeString = `${sizeInGb.toFixed(2)} GB`;
+        } else {
+          sizeString = `${sizeInMb.toFixed(2)} MB`;
+        }
+        report += `Size: ${sizeString}`
+      });
+      return report;
+    } catch (error) {
+      return error.message;
+    }
+}
+
+async function getCacheData() {
+    const { Octokit } = require("@octokit/action");
+    const { Octokit, App } = require("octokit");
+    const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+    const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+    const response = await octokit.request('GET /repos/{owner}/{repo}/actions/caches', {
+        owner: owner,
+        repo: repo
+    });
+    return response.data;
+}

--- a/.github/scripts/report-mail-sender.js
+++ b/.github/scripts/report-mail-sender.js
@@ -1,4 +1,4 @@
-module.exports = ({ }) => {
+module.exports = (subject, report) => {
     const execSync = require('child_process').execSync
     execSync(`npm install nodemailer`)
     const nodemailer = require('nodemailer')
@@ -9,7 +9,6 @@ module.exports = ({ }) => {
             pass: `${process.env.MAIL_PASSWORD}`
         }
     });
-    const report = require('fs').readFileSync('build/dependencyUpdates/dependency_update_report.txt', 'utf8')
 
     const mailOptions = {
         from: {
@@ -17,7 +16,7 @@ module.exports = ({ }) => {
             address: process.env.MAIL_USERNAME
         },
         to: 'yasinkacmaz57@gmail.com',
-        subject: 'Dependency update report of Jetflix ¯\\_(ツ)_/¯',
+        subject: `${subject}`,
         text: `${report}`
     };
 

--- a/.github/workflows/check-dependency-updates.yml
+++ b/.github/workflows/check-dependency-updates.yml
@@ -5,12 +5,12 @@ on:
   workflow_dispatch:
 jobs:
   dependency-updates:
-    runs-on: ubuntu-latest
     timeout-minutes: 10
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Use Java 11
+      - name: Setup Java
         uses: actions/setup-java@v3
         with:
           distribution: 'corretto'
@@ -32,9 +32,11 @@ jobs:
           MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
         with:
           script: |
-            const scriptPath = '/./.github/scripts/dependency-update-report-mail-sender.js'
-            const script = require(`${process.env.GITHUB_WORKSPACE}${scriptPath}`)
-            script({ })
+            const subject = `Dependency update report of Jetflix ¯\\_(ツ)_/¯`
+            const report = require('fs').readFileSync('build/dependencyUpdates/dependency_update_report.txt', 'utf8')
+            const mailSenderScriptPath = '/./.github/scripts/dependency-update-report-mail-sender.js'
+            const mailSenderScript = require(`${process.env.GITHUB_WORKSPACE}${mailSenderScriptPath}`)
+            mailSenderScript(subject, report)
       - name: Share dependency update reports
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/update-build-cache.yml
+++ b/.github/workflows/update-build-cache.yml
@@ -1,0 +1,77 @@
+name: Update Build Cache
+on:
+  schedule:
+    - cron: "37 13 * * SAT"
+  workflow_dispatch:
+jobs:
+  update-cache:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    env:
+      androidApiVersion: 23
+      buildToolsVersion: 33.0.0
+      # TODO: Build tools version at here is fixed:
+      # https://github.com/ReactiveCircus/android-emulator-runner/blob/main/src/sdk-installer.ts#L7
+      # Update the version when it changes
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: '17'
+          cache: 'gradle'
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+      - name: Make user owner of Android Sdk directory
+        run: sudo chown $USER:$USER /usr/local/lib/android/sdk -R
+      - name: Fetch AVD Cache
+        uses: actions/cache@v3
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: ${{ runner.os }}-avd-${{ env.androidApiVersion }}
+      - name: Fetch Android SDK Cache
+        uses: actions/cache@v3
+        id: android-sdk-cache
+        with:
+          path: |
+           /usr/local/lib/android/sdk/emulator
+           /usr/local/lib/android/sdk/build-tools/${{ env.buildToolsVersion }}
+           /usr/local/lib/android/sdk/platform-tools
+           /usr/local/lib/android/sdk/platforms/android-${{ env.androidApiVersion }}
+           /usr/local/lib/android/sdk/system-images/android-${{ env.androidApiVersion }}
+          key: ${{ runner.os }}-android-sdk-${{ env.androidApiVersion }}
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ env.androidApiVersion }}
+          arch: x86_64
+          ram-size: 2048M
+          disk-size: 1536M
+          force-avd-creation: false
+          disable-animations: true
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          script: echo "Generated AVD snapshot for caching."
+      - name: 🚧 Build and Update Cache
+        run: ./gradlew build
+      - name: 💌 Send email report
+        uses: actions/github-script@v6
+        env:
+          MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
+          MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
+        with:
+          script: |
+            const subject = `Github Actions cache status of Jetflix ¯\\_(ツ)_/¯`
+            const reportGeneratorScriptPath = '/./.github/scripts/cache-update-report-generator.js'
+            const reportGeneratorScript = require(`${process.env.GITHUB_WORKSPACE}${reportGeneratorScriptPath}`)
+            const report = reportGeneratorScript()
+            const mailSenderScriptPath = '/./.github/scripts/dependency-update-report-mail-sender.js'
+            const mailSenderScript = require(`${process.env.GITHUB_WORKSPACE}${mailSenderScriptPath}`)
+            mailSenderScript(subject, report)


### PR DESCRIPTION
This pr aims to have a persistent Github Actions cache by creating and updating it weekly basis.
Why weekly?:

In [Github Actions Cache Policy](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy) it says:

> GitHub will remove any cache entries that have not been accessed in over 7 days.

By running the script once a week automatically, we will ensure that the cache is persistent and not deleted by Github.