### PR TITLE
Have manual gradle cache on github actions

### DIFF
--- a/.github/scripts/gradle-version-detector.js
+++ b/.github/scripts/gradle-version-detector.js
@@ -1,0 +1,22 @@
+module.exports = () => {
+    const fs = require('fs');
+    const path = require('path');
+    const projectRoot = path.resolve(process.cwd());
+    const propertiesFilePath = path.join(projectRoot, 'gradle/wrapper/gradle-wrapper.properties');
+    const fileContent = fs.readFileSync(propertiesFilePath, 'utf8');
+    const lines = fileContent.split(/\r?\n/);
+
+    let gradleVersion = '';
+    lines.forEach((line) => {
+        if (line.includes("distributionUrl")) {
+            gradleVersion = line.split('/').pop();
+        }
+    });
+
+    if (gradleVersion === "") {
+        throw new Error('Unable to find gradle version from gradle-wrapper.properties file');
+    } else {
+        console.log(`Found gradle version : ${gradleVersion}`);
+        return gradleVersion;
+    }
+}

--- a/.github/workflows/build-apk-bundle.yml
+++ b/.github/workflows/build-apk-bundle.yml
@@ -12,7 +12,22 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: '17'
-          cache: 'gradle'
+      - name: Detect gradle version
+        uses: actions/github-script@v6
+        id: gradle-version-detector
+        with:
+          result-encoding: string
+          script: |
+            const scriptPath = '/./.github/scripts/gradle-version-detector.js'
+            const script = require(`${process.env.GITHUB_WORKSPACE}${scriptPath}`)
+            return script()
+      - name: Fetch gradle cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-${{ steps.gradle-version-detector.outputs.result }}
       - name: Copy Signing Properties
         run: |
           echo "${{ secrets.JETFLIX_KEYSTORE }}" > jetflix.keystore.asc

--- a/.github/workflows/check-dependency-updates.yml
+++ b/.github/workflows/check-dependency-updates.yml
@@ -15,7 +15,22 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: '17'
-          cache: 'gradle'
+      - name: Detect gradle version
+        uses: actions/github-script@v6
+        id: gradle-version-detector
+        with:
+          result-encoding: string
+          script: |
+            const scriptPath = '/./.github/scripts/gradle-version-detector.js'
+            const script = require(`${process.env.GITHUB_WORKSPACE}${scriptPath}`)
+            return script()
+      - name: Fetch gradle cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-${{ steps.gradle-version-detector.outputs.result }}
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
       - name: Make gradlew executable

--- a/.github/workflows/ktlint.yml
+++ b/.github/workflows/ktlint.yml
@@ -14,7 +14,22 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: '17'
-          cache: 'gradle'
+      - name: Detect gradle version
+        uses: actions/github-script@v6
+        id: gradle-version-detector
+        with:
+          result-encoding: string
+          script: |
+            const scriptPath = '/./.github/scripts/gradle-version-detector.js'
+            const script = require(`${process.env.GITHUB_WORKSPACE}${scriptPath}`)
+            return script()
+      - name: Fetch gradle cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-${{ steps.gradle-version-detector.outputs.result }}
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
       - name: Make gradlew executable

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -20,7 +20,22 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: '17'
-          cache: 'gradle'
+      - name: Detect gradle version
+        uses: actions/github-script@v6
+        id: gradle-version-detector
+        with:
+          result-encoding: string
+          script: |
+            const scriptPath = '/./.github/scripts/gradle-version-detector.js'
+            const script = require(`${process.env.GITHUB_WORKSPACE}${scriptPath}`)
+            return script()
+      - name: Fetch gradle cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-${{ steps.gradle-version-detector.outputs.result }}
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
       - name: Make gradlew executable

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -14,7 +14,22 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: '17'
-          cache: 'gradle'
+      - name: Detect gradle version
+        uses: actions/github-script@v6
+        id: gradle-version-detector
+        with:
+          result-encoding: string
+          script: |
+            const scriptPath = '/./.github/scripts/gradle-version-detector.js'
+            const script = require(`${process.env.GITHUB_WORKSPACE}${scriptPath}`)
+            return script()
+      - name: Fetch gradle cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-${{ steps.gradle-version-detector.outputs.result }}
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
       - name: Make gradlew executable

--- a/.github/workflows/update-build-cache.yml
+++ b/.github/workflows/update-build-cache.yml
@@ -21,7 +21,22 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: '17'
-          cache: 'gradle'
+      - name: Detect gradle version
+        uses: actions/github-script@v6
+        id: gradle-version-detector
+        with:
+          result-encoding: string
+          script: |
+            const scriptPath = '/./.github/scripts/gradle-version-detector.js'
+            const script = require(`${process.env.GITHUB_WORKSPACE}${scriptPath}`)
+            return script()
+      - name: Fetch gradle cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-${{ steps.gradle-version-detector.outputs.result }}
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
       - name: Make gradlew executable
@@ -60,7 +75,7 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           script: echo "Generated AVD snapshot for caching."
       - name: 🚧 Build and Update Cache
-        run: ./gradlew build
+        run: ./gradlew assembleDebug
       - name: 💌 Send email report
         uses: actions/github-script@v6
         env:


### PR DESCRIPTION
GitHub [actions/setup-java](https://github.com/actions/setup-java#caching-packages-dependencies) has its own [Gradle cache](https://github.com/actions/setup-java#caching-packages-dependencies)
It generates a hash to store the cache and we have no control over it.

With this pr, the cache key will be converted
from:
`setup-java-Linux-gradle-c3cb620ab35bbc6964e4cac8034d8ecd198xx1ea1169a3f9c65d3adc580078ee`
to
`Linux-gradle-8.0-rc-2-bin.zip`

The cache will be regenerated only when the Gradle version changes.
It will be more human-readable and the cache will not become invalid when any of the Gradle files change or when a dependency version is updated.
