### PR TITLE
Fix movies lazy grid paging

### DIFF
--- a/app/src/main/java/com/yasinkacmaz/jetflix/ui/movies/MoviesGrid.kt
+++ b/app/src/main/java/com/yasinkacmaz/jetflix/ui/movies/MoviesGrid.kt
@@ -91,9 +91,14 @@ private fun LazyMoviesGrid(state: LazyGridState, moviePagingItems: LazyPagingIte
                     ErrorRow(stringResource(R.string.no_movies_found))
                 }
             }
-            items(moviePagingItems.itemCount) { index ->
-                val movie = moviePagingItems.peek(index) ?: return@items
-                MovieContent(movie, Modifier.height(320.dp), onMovieClicked,)
+            items(
+                moviePagingItems.itemCount,
+                key = { moviePagingItems[it]?.id ?: -1 }
+            ) { index ->
+                val movie = moviePagingItems.peek(index)
+                movie?.let {
+                    MovieContent(it, Modifier.height(320.dp), onMovieClicked)
+                }
             }
             renderLoading(moviePagingItems.loadState)
             renderError(moviePagingItems.loadState)


### PR DESCRIPTION
MoviesLazyGrid paging wasn't working for a long time. It was only fetching initial data and was unable to fetch the next pages when scrolling to the bottom.

With proper key management for each item, LazyGrid scrolling will behave correctly.
In the future, a placeholder can be rendered when we have the movie item as null. For now, we don't render anything.