### PR TITLE
Enable CI emulator hardware acceleration with KVM

### DIFF
--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -44,7 +44,12 @@ jobs:
             ~/.android/avd/*
             ~/.android/adb*
           key: ${{ runner.os }}-avd-${{ env.androidApiVersion }}
-      - name: Create AVD and generate snapshot for caching
+      - name: Enable KVM group permissions for emulator hardware acceleration
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: 📱 Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:


### PR DESCRIPTION
Enabling **KVM** support significantly enhances the performance of emulators on GitHub Action runners.
**Jetflix UI Test Action** run times improved from an inconsistent **10-12** minutes to a steady **2-3** minutes.

Feel free to check here for more information:
https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
https://github.blog/news-insights/product-news/github-hosted-runners-double-the-power-for-open-source/