### PR TITLE
Move ui tests under commonTest module

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,5 +1,5 @@
+import org.jetbrains.compose.ExperimentalComposeLibrary
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.nio.charset.Charset
 import java.util.Properties
@@ -45,8 +45,6 @@ kotlin {
             implementation(libs.androidX.splashscreen)
             implementation(libs.koin.android)
             implementation(libs.ktor.client.okhttp)
-            //    debugImplementation(libs.androidX.tracing)
-//    debugImplementation(libs.compose.testManifest)
         }
         iosMain.dependencies {
             implementation(libs.ktor.client.darwin)
@@ -90,6 +88,8 @@ kotlin {
             implementation(libs.kotlin.test)
             implementation(libs.kotlinx.coroutines.test)
             implementation(libs.kotest.assertions)
+            @OptIn(ExperimentalComposeLibrary::class)
+            implementation(compose.uiTest)
         }
 
         desktopMain.dependencies {

--- a/composeApp/src/commonTest/kotlin/com/yasinkacmaz/jetflix/uiTest/filter/FilterBottomSheetTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/yasinkacmaz/jetflix/uiTest/filter/FilterBottomSheetTest.kt
@@ -1,4 +1,4 @@
-package com.yasinkacmaz.jetflix.filter
+package com.yasinkacmaz.jetflix.uiTest.filter
 
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.test.ComposeUiTest
@@ -18,17 +18,18 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.test.swipeUp
-import com.yasinkacmaz.jetflix.R
 import com.yasinkacmaz.jetflix.data.remote.Genre
 import com.yasinkacmaz.jetflix.ui.filter.FilterBottomSheet
 import com.yasinkacmaz.jetflix.ui.filter.FilterState
 import com.yasinkacmaz.jetflix.ui.filter.genres.GenreUiModel
 import com.yasinkacmaz.jetflix.ui.filter.option.SortBy
 import com.yasinkacmaz.jetflix.ui.filter.option.SortOrder
-import com.yasinkacmaz.jetflix.util.getString
-import com.yasinkacmaz.jetflix.util.setTestContent
-import com.yasinkacmaz.jetflix.util.withRole
-import org.junit.Test
+import com.yasinkacmaz.jetflix.uiTest.util.setTestContent
+import com.yasinkacmaz.jetflix.uiTest.util.withRole
+import com.yasinkacmaz.jetflix.uiTest.util.withStringResource
+import jetflix.composeapp.generated.resources.Res
+import jetflix.composeapp.generated.resources.include_adult
+import kotlin.test.Test
 
 @OptIn(ExperimentalTestApi::class)
 class FilterBottomSheetTest {
@@ -37,7 +38,7 @@ class FilterBottomSheetTest {
     private val genres = genreNames.mapIndexed { index, name -> GenreUiModel(genre = Genre(id = index, name = name)) }
 
     @Test
-    fun testFilterComponents() = runComposeUiTest {
+    fun `Should render filter components correctly`() = runComposeUiTest {
         val filterState =
             FilterState(sortOrder = SortOrder.ASCENDING, sortBy = SortBy.REVENUE, includeAdult = true, genres = genres)
 
@@ -46,13 +47,13 @@ class FilterBottomSheetTest {
         }
 
         ensureBottomSheetFullyVisible()
-        verifySortBySelected(filterState.sortBy)
+        verifySortBySelected(withStringResource(filterState.sortBy.title))
         verifyIncludeAdult(filterState.includeAdult)
-        onNodeWithText(getString(SortOrder.DESCENDING.titleResId)).performClick()
-        onNodeWithText(getString(SortBy.POPULARITY.titleResId)).performClick()
+        onNodeWithText(withStringResource(SortOrder.DESCENDING.title)).performClick()
+        onNodeWithText(withStringResource(SortBy.POPULARITY.title)).performClick()
         includeAdultNode().performClick()
-        verifySortOrderSelected(SortOrder.DESCENDING)
-        verifySortBySelected(SortBy.POPULARITY)
+        verifySortOrderSelected(withStringResource(SortOrder.DESCENDING.title))
+        verifySortBySelected(withStringResource(SortBy.POPULARITY.title))
         verifyIncludeAdult(!filterState.includeAdult)
 
         genreNames.forEach { genreName ->
@@ -67,13 +68,11 @@ class FilterBottomSheetTest {
         includeAdultNode().performTouchInput { swipeUp() }
     }
 
-    private fun ComposeUiTest.verifySortOrderSelected(sortOrder: SortOrder) {
-        val sortOrderTitle = getString(sortOrder.titleResId)
+    private fun ComposeUiTest.verifySortOrderSelected(sortOrderTitle: String) {
         onNode(withRole(Role.RadioButton).and(isSelected()).and(hasText(sortOrderTitle))).assertIsDisplayed()
     }
 
-    private fun ComposeUiTest.verifySortBySelected(sortBy: SortBy) {
-        val sortByTitle = getString(sortBy.titleResId)
+    private fun ComposeUiTest.verifySortBySelected(sortByTitle: String) {
         onNode(withRole(Role.RadioButton).and(isSelected()).and(hasText(sortByTitle))).assertIsDisplayed()
     }
 
@@ -82,5 +81,5 @@ class FilterBottomSheetTest {
         includeAdultNode().assert(hasAnyChild(isToggleable().and(matcher)))
     }
 
-    private fun ComposeUiTest.includeAdultNode() = onNodeWithText(getString(R.string.include_adult))
+    private fun ComposeUiTest.includeAdultNode() = onNodeWithText(withStringResource(Res.string.include_adult))
 }

--- a/composeApp/src/commonTest/kotlin/com/yasinkacmaz/jetflix/uiTest/movie/MovieContentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/yasinkacmaz/jetflix/uiTest/movie/MovieContentTest.kt
@@ -1,4 +1,4 @@
-package com.yasinkacmaz.jetflix.movie
+package com.yasinkacmaz.jetflix.uiTest.movie
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
@@ -8,14 +8,14 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runComposeUiTest
 import com.yasinkacmaz.jetflix.ui.movies.movie.Movie
 import com.yasinkacmaz.jetflix.ui.movies.movie.MovieItem
-import com.yasinkacmaz.jetflix.util.setTestContent
-import org.junit.Test
+import com.yasinkacmaz.jetflix.uiTest.util.setTestContent
+import kotlin.test.Test
 
 @OptIn(ExperimentalTestApi::class)
 class MovieContentTest {
 
     @Test
-    fun should_render_basic_movie_information() = runComposeUiTest {
+    fun `Should render movie item correctly`() = runComposeUiTest {
         val movie = Movie(
             id = 1337,
             name = "Movie Name",

--- a/composeApp/src/commonTest/kotlin/com/yasinkacmaz/jetflix/uiTest/moviedetail/MovieDetailScreenTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/yasinkacmaz/jetflix/uiTest/moviedetail/MovieDetailScreenTest.kt
@@ -1,10 +1,5 @@
-package com.yasinkacmaz.jetflix.moviedetail
+package com.yasinkacmaz.jetflix.uiTest.moviedetail
 
-import androidx.annotation.StringRes
-import androidx.compose.animation.Animatable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.remember
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertCountEquals
@@ -15,16 +10,16 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.runComposeUiTest
-import com.yasinkacmaz.jetflix.R
-import com.yasinkacmaz.jetflix.ui.moviedetail.LocalVibrantColor
 import com.yasinkacmaz.jetflix.ui.moviedetail.MovieDetail
 import com.yasinkacmaz.jetflix.ui.moviedetail.credits.Credits
 import com.yasinkacmaz.jetflix.ui.moviedetail.credits.Gender
 import com.yasinkacmaz.jetflix.ui.moviedetail.credits.Person
-import com.yasinkacmaz.jetflix.util.getString
-import com.yasinkacmaz.jetflix.util.randomColor
-import com.yasinkacmaz.jetflix.util.setTestContent
-import org.junit.Test
+import com.yasinkacmaz.jetflix.uiTest.util.setTestContent
+import com.yasinkacmaz.jetflix.uiTest.util.withStringResource
+import jetflix.composeapp.generated.resources.Res
+import jetflix.composeapp.generated.resources.cast
+import jetflix.composeapp.generated.resources.crew
+import kotlin.test.Test
 
 @OptIn(ExperimentalTestApi::class)
 class MovieDetailScreenTest {
@@ -41,28 +36,45 @@ class MovieDetailScreenTest {
     )
 
     @Test
-    fun should_not_render_original_title_if_same_with_name() = runComposeUiTest {
+    fun `Should not render original title if its same with title`() = runComposeUiTest {
         val title = "Title"
         val originalTitle = "Title"
 
-        renderMovieDetail(movieDetail.copy(title = title, originalTitle = originalTitle))
-
+        setTestContent {
+            MovieDetail(
+                movieDetail = movieDetail.copy(title = title, originalTitle = originalTitle),
+                cast = emptyList(),
+                crew = emptyList(),
+                images = listOf(),
+                isFavorite = false,
+                onFavoriteClicked = {},
+            )
+        }
         onAllNodesWithText(title, useUnmergedTree = false).assertCountEquals(1)
     }
 
     @Test
-    fun should_render_original_title_with_parentheses_if_different_from_name() = runComposeUiTest {
+    fun `Should render original title with parentheses if its different from title`() = runComposeUiTest {
         val title = "Title"
         val originalTitle = "Original Title"
 
-        renderMovieDetail(movieDetail.copy(title = title, originalTitle = originalTitle))
+        setTestContent {
+            MovieDetail(
+                movieDetail = movieDetail.copy(title = title, originalTitle = originalTitle),
+                cast = emptyList(),
+                crew = emptyList(),
+                images = listOf(),
+                isFavorite = false,
+                onFavoriteClicked = {},
+            )
+        }
 
         onNodeWithText(title, useUnmergedTree = false).assertIsDisplayed()
         onNodeWithText("($originalTitle)", useUnmergedTree = false).assertIsDisplayed()
     }
 
     @Test
-    fun should_render_movie_info() = runComposeUiTest {
+    fun `Should render movie detail correctly`() = runComposeUiTest {
         val person = Person(name = "", role = "", profilePhotoUrl = null, gender = Gender.FEMALE, id = 1337)
         val credits = Credits(
             cast = listOf(
@@ -74,8 +86,16 @@ class MovieDetailScreenTest {
                 person.copy("J.K. Rowling", "Novel", gender = Gender.FEMALE),
             ),
         )
-        renderMovieDetail(movieDetail, credits)
-
+        setTestContent {
+            MovieDetail(
+                movieDetail = movieDetail,
+                cast = credits.cast,
+                crew = credits.crew,
+                images = listOf(),
+                isFavorite = false,
+                onFavoriteClicked = {},
+            )
+        }
         onNodeWithText(movieDetail.releaseDate).performScrollTo()
         onNodeWithText(movieDetail.releaseDate, useUnmergedTree = false).assertIsDisplayed()
         onNodeWithText("${movieDetail.duration} min", useUnmergedTree = false).assertIsDisplayed()
@@ -86,33 +106,16 @@ class MovieDetailScreenTest {
         onNodeWithText(movieDetail.tagline, useUnmergedTree = false).assertIsDisplayed()
         onNodeWithText(movieDetail.overview).performScrollTo()
         onNodeWithText(movieDetail.overview, useUnmergedTree = false).assertIsDisplayed()
-        assertPeople(R.string.cast, credits.cast)
-        assertPeople(R.string.crew, credits.crew)
+        assertPeople(withStringResource(Res.string.cast), credits.cast)
+        assertPeople(withStringResource(Res.string.crew), credits.crew)
     }
 
-    private fun ComposeUiTest.assertPeople(@StringRes tagResId: Int, people: List<Person>) {
-        val peopleLazyRow = onNodeWithTag(getString(tagResId)).performScrollTo()
+    private fun ComposeUiTest.assertPeople(tag: String, people: List<Person>) {
+        val peopleLazyRow = onNodeWithTag(tag).performScrollTo()
         people.forEachIndexed { index, person ->
             peopleLazyRow.performScrollToIndex(index)
             onNodeWithText(person.name, ignoreCase = false, useUnmergedTree = false).assertIsDisplayed()
             onNodeWithText(person.role, ignoreCase = false, useUnmergedTree = false).assertIsDisplayed()
-        }
-    }
-
-    private fun ComposeUiTest.renderMovieDetail(
-        movieDetail: MovieDetail,
-        credits: Credits = Credits(emptyList(), emptyList()),
-    ) = setTestContent {
-        val dominantColor = remember(movieDetail.id) { Animatable(Color.randomColor()) }
-        CompositionLocalProvider(LocalVibrantColor provides dominantColor) {
-            MovieDetail(
-                movieDetail = movieDetail,
-                cast = credits.cast,
-                crew = credits.crew,
-                images = listOf(),
-                isFavorite = false,
-                onFavoriteClicked = {},
-            )
         }
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/yasinkacmaz/jetflix/uiTest/settings/SettingsDialogTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/yasinkacmaz/jetflix/uiTest/settings/SettingsDialogTest.kt
@@ -1,19 +1,19 @@
-package com.yasinkacmaz.jetflix.settings
+package com.yasinkacmaz.jetflix.uiTest.settings
 
-import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
-import com.yasinkacmaz.jetflix.R
 import com.yasinkacmaz.jetflix.ui.settings.Language
 import com.yasinkacmaz.jetflix.ui.settings.SettingsDialogContent
 import com.yasinkacmaz.jetflix.ui.settings.SettingsViewModel
 import com.yasinkacmaz.jetflix.ui.settings.displayName
-import com.yasinkacmaz.jetflix.util.getString
-import com.yasinkacmaz.jetflix.util.setTestContent
-import org.junit.Test
+import com.yasinkacmaz.jetflix.uiTest.util.setTestContent
+import com.yasinkacmaz.jetflix.uiTest.util.withStringResource
+import jetflix.composeapp.generated.resources.Res
+import jetflix.composeapp.generated.resources.fetching_languages
+import kotlin.test.Test
 
 @OptIn(ExperimentalTestApi::class)
 class SettingsDialogTest {
@@ -21,25 +21,29 @@ class SettingsDialogTest {
     private val defaultLanguage = Language("Turkish", "tr", "Türkçe")
 
     @Test
-    fun should_render_loading_when_uiState_showLoading_is_true() = runComposeUiTest {
+    fun `Should render loading state`() = runComposeUiTest {
         val uiState = SettingsViewModel.UiState(showLoading = true)
 
-        showSettingsDialog(uiState)
+        setTestContent {
+            SettingsDialogContent(uiState = uiState, onLanguageSelected = {})
+        }
 
-        onNodeWithText(getString(R.string.fetching_languages), useUnmergedTree = true).assertIsDisplayed()
+        onNodeWithText(withStringResource(Res.string.fetching_languages), useUnmergedTree = true).assertIsDisplayed()
     }
 
     @Test
-    fun should_render_selected_language() = runComposeUiTest {
+    fun `Should render selected language`() = runComposeUiTest {
         val uiState = SettingsViewModel.UiState(selectedLanguage = defaultLanguage)
 
-        showSettingsDialog(uiState)
+        setTestContent {
+            SettingsDialogContent(uiState = uiState, onLanguageSelected = {})
+        }
 
         onNodeWithText(defaultLanguage.displayName, substring = true, useUnmergedTree = true).assertIsDisplayed()
     }
 
     @Test
-    fun should_render_languages_when_selected_language_clicked() = runComposeUiTest {
+    fun `Should render languages when selected language clicked`() = runComposeUiTest {
         val firstLanguageName = "English"
         val secondLanguageName = "Russian"
         val thirdLanguageName = "Chinese"
@@ -50,15 +54,13 @@ class SettingsDialogTest {
         )
         val uiState = SettingsViewModel.UiState(languages = languages, selectedLanguage = defaultLanguage)
 
-        showSettingsDialog(uiState)
+        setTestContent {
+            SettingsDialogContent(uiState = uiState, onLanguageSelected = {})
+        }
         onNodeWithText(defaultLanguage.displayName, substring = true, useUnmergedTree = true).performClick()
 
         languages.forEach {
             onNodeWithText(it.englishName, substring = true, useUnmergedTree = true).assertIsDisplayed()
         }
-    }
-
-    private fun ComposeUiTest.showSettingsDialog(uiState: SettingsViewModel.UiState) = setTestContent {
-        SettingsDialogContent(uiState = uiState, onLanguageSelected = {})
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/yasinkacmaz/jetflix/uiTest/util/Matcher.kt
+++ b/composeApp/src/commonTest/kotlin/com/yasinkacmaz/jetflix/uiTest/util/Matcher.kt
@@ -1,11 +1,18 @@
-package com.yasinkacmaz.jetflix.util
+package com.yasinkacmaz.jetflix.uiTest.util
 
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsMatcher
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.getString
 
 fun withRole(role: Role) = SemanticsMatcher("${SemanticsProperties.Role.name} contains '$role'") {
     val roleProperty = it.config.getOrNull(SemanticsProperties.Role) ?: false
     roleProperty == role
+}
+
+fun withStringResource(resource: StringResource): String {
+    return runBlocking { getString(resource) }
 }

--- a/composeApp/src/commonTest/kotlin/com/yasinkacmaz/jetflix/uiTest/util/Utils.kt
+++ b/composeApp/src/commonTest/kotlin/com/yasinkacmaz/jetflix/uiTest/util/Utils.kt
@@ -1,7 +1,5 @@
-package com.yasinkacmaz.jetflix.util
+package com.yasinkacmaz.jetflix.uiTest.util
 
-import android.content.Context
-import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
@@ -14,14 +12,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.navigation.compose.rememberNavController
-import androidx.test.platform.app.InstrumentationRegistry
-import com.yasinkacmaz.jetflix.ui.main.LocalNavController
+import com.yasinkacmaz.jetflix.LocalNavController
 import com.yasinkacmaz.jetflix.ui.theme.JetflixTheme
-
-fun getString(@StringRes resId: Int): String {
-    val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
-    return context.getString(resId)
-}
 
 @OptIn(ExperimentalTestApi::class)
 fun ComposeUiTest.setTestContent(content: @Composable BoxScope.() -> Unit) = setContent {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,4 @@ coil-network-ktor = { module = "io.coil-kt.coil3:coil-network-ktor3", version.re
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotest-assertions = { module = "io.kotest:kotest-assertions-core", version = "5.9.1" }
 
-androidX_tracing = { module = "androidx.tracing:tracing", version = "1.2.0" }
 androidX-splashscreen = { module = "androidx.core:core-splashscreen", version = "1.2.0-beta01" }
-
-compose_testManifest = { module = "androidx.compose.ui:ui-test-manifest", version = "1.8.0-rc01" }


### PR DESCRIPTION
This is the recommended way to write common UI tests: https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-test.html#write-and-run-common-tests

For now, we can run all the tests on Desktop and iOS, but not on Android.

There is currently no separation between UI and unit tests since they’re in the same package. We could exclude the folder from unit tests, but I won’t do that since it’s fine to run all tests together from now on.

This will be helpful for CI, and I’ll check if running tests in a Desktop environment is faster. Also, avoiding the Android emulator should help with CI storage and overall duration.